### PR TITLE
Fixed wrong version in pkgconfig file

### DIFF
--- a/debian/nuget-core.pc
+++ b/debian/nuget-core.pc
@@ -6,6 +6,6 @@ Libraries=${prefix}/lib/nuget/NuGet.Core.dll ${prefix}/lib/nuget/Microsoft.Web.X
 
 Name: nuget-core
 Description: nuget-core - Library for acessing Microsoft NuGet repositories
-Version: 2.8.1
+Version: 2.8.5
 Libs: -r:${prefix}/lib/nuget/NuGet.Core.dll -r:${prefix}/lib/nuget/Microsoft.Web.XmlTransform.dll
 


### PR DESCRIPTION
It is a bit sad to see Debian exclusive .pc files. I maintain one myself at @openSUSE. This is certainly not good for cross-distribution compatibility.
